### PR TITLE
Add custom operation `useTokenReplacer`

### DIFF
--- a/src/FSharp.SystemCommandLine/CommandBuilders.fs
+++ b/src/FSharp.SystemCommandLine/CommandBuilders.fs
@@ -333,6 +333,11 @@ type RootCommandParserBuilder<'A, 'B, 'C, 'D, 'E, 'F, 'G, 'H, 'Output>() =
     member this.UsePipeline (spec: CommandSpec<'Inputs, 'Output>, subCommand: CommandLineBuilder -> CommandLineBuilder) =
         this.CommandLineBuilder <- subCommand this.CommandLineBuilder
         spec
+
+    [<CustomOperation("useTokenReplacer")>]
+    member this.UseTokenReplacer(spec: CommandSpec<'Inputs, 'Output>, replacer: TryReplaceToken) =
+        this.CommandLineBuilder.UseTokenReplacer(replacer) |> ignore
+        spec
         
     /// Executes a Command with a handler that returns unit.
     member this.Run (spec: CommandSpec<'Inputs, unit>) =
@@ -371,6 +376,11 @@ type RootCommandBuilder<'A, 'B, 'C, 'D, 'E, 'F, 'G, 'H, 'Output>(args: string ar
     [<CustomOperation("usePipeline")>]
     member this.UsePipeline (spec: CommandSpec<'Inputs, 'Output>, subCommand: CommandLineBuilder -> CommandLineBuilder) =
         this.CommandLineBuilder <- subCommand this.CommandLineBuilder
+        spec
+        
+    [<CustomOperation("useTokenReplacer")>]
+    member this.UseTokenReplacer(spec: CommandSpec<'Inputs, 'Output>, replacer: TryReplaceToken) =
+        this.CommandLineBuilder.UseTokenReplacer(replacer) |> ignore
         spec
 
     /// Executes a Command with a handler that returns unit.

--- a/src/TestConsole/ProgramTokenReplacer.fs
+++ b/src/TestConsole/ProgramTokenReplacer.fs
@@ -1,0 +1,29 @@
+﻿module ProgramTokenReplacer
+
+open FSharp.SystemCommandLine
+open System.CommandLine.Parsing
+
+let app (package: string) =
+    if package.StartsWith("@") then
+        printfn $"{package}"
+        0
+    else
+        eprintfn "The package name does not start with a leading @"
+        1
+
+//[<EntryPoint>]
+let main argv =
+    let package =
+        Input.Option([ "--package"; "-p" ], "A package with a leading @ name")
+
+    rootCommand argv {
+        description "Can be called with a leading @ package"
+
+        useTokenReplacer (
+            // in this case we want to skip @ processing
+            TryReplaceToken (fun _ _ _ -> false)
+        )
+
+        inputs package
+        setHandler app
+    }

--- a/src/TestConsole/Properties/launchSettings.json
+++ b/src/TestConsole/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "TestConsole": {
       "commandName": "Project",
       "commandLineArgs": "-w hello -w world"
+    },
+    "Leading @": {
+      "commandName": "Project",
+      "commandLineArgs": "--package @shoelace-style/shoelace"
     }
   }
 }

--- a/src/TestConsole/TestConsole.fsproj
+++ b/src/TestConsole/TestConsole.fsproj
@@ -12,9 +12,8 @@
     <Compile Include="ProgramSubCommand.fs" />
     <Compile Include="ProgramTask.fs" />
     <Compile Include="Program.fs" />
+    <Compile Include="ProgramTokenReplacer.fs" />
   </ItemGroup>
-
-  <ItemGroup />
 
   <ItemGroup>
     <ProjectReference Include="..\FSharp.SystemCommandLine\FSharp.SystemCommandLine.fsproj" />

--- a/src/TestConsole/TestConsole.fsproj
+++ b/src/TestConsole/TestConsole.fsproj
@@ -11,8 +11,8 @@
     <Compile Include="ProgramNoArgs.fs" />
     <Compile Include="ProgramSubCommand.fs" />
     <Compile Include="ProgramTask.fs" />
-    <Compile Include="Program.fs" />
     <Compile Include="ProgramTokenReplacer.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This adds a custom operation to allow us to by-pass a new SCL feature that takes any prefixed `@` strings with certain configuration files more info [here](https://github.com/dotnet/command-line-api/issues/1750)

I got some pointers from Chet [to add a `TryReplaceToken` delegate](https://github.com/dotnet/command-line-api/issues/1877) so skip this token processing

I wasn't sure how to add a rootCommandTest for this change because it initializes a parser in the helper itself and the parser has to also have a `TryReplaceToken` delegate for it to work properly, so I added a manual test in the TestConsole project