### PR TITLE
Add Support for Command  Aliases

### DIFF
--- a/src/FSharp.SystemCommandLine/CommandBuilders.fs
+++ b/src/FSharp.SystemCommandLine/CommandBuilders.fs
@@ -124,11 +124,11 @@ type BaseCommandBuilder<'A, 'B, 'C, 'D, 'E, 'F, 'G, 'H, 'Output>() =
         { spec with SubCommands = spec.SubCommands @ (subCommands |> Seq.toList) }
 
     [<CustomOperation("addAlias")>]
-    member this.AddCommands (spec: CommandSpec<'Inputs, 'Output>, alias: string seq) =
+    member this.AddAlias (spec: CommandSpec<'Inputs, 'Output>, alias: string seq) =
         { spec with Alias = spec.Alias @ (alias |> Seq.toList) }
 
     [<CustomOperation("addAlias")>]
-    member this.AddCommands (spec: CommandSpec<'Inputs, 'Output>, alias: string) =
+    member this.AddAlias (spec: CommandSpec<'Inputs, 'Output>, alias: string) =
         { spec with Alias = alias :: spec.Alias }
 
     /// Registers an additional input that can be manually parsed via the InvocationContext. (Use when more than 8 inputs are required.)

--- a/src/FSharp.SystemCommandLine/CommandBuilders.fs
+++ b/src/FSharp.SystemCommandLine/CommandBuilders.fs
@@ -22,6 +22,7 @@ type CommandSpec<'Inputs, 'Output> =
         Description: string
         Inputs: HandlerInput list
         Handler: 'Inputs -> 'Output
+        Alias: string list
         SubCommands: System.CommandLine.Command list
         /// Registers extra inputs that can be parsed via the InvocationContext if more than 8 are required.
         ExtraInputs: HandlerInput list
@@ -30,6 +31,7 @@ type CommandSpec<'Inputs, 'Output> =
         { 
             Description = "My Command"
             Inputs = []
+            Alias = []
             ExtraInputs = []
             Handler = def<unit -> 'Output> // Support unit -> 'Output handler by default
             SubCommands = []
@@ -42,6 +44,7 @@ type BaseCommandBuilder<'A, 'B, 'C, 'D, 'E, 'F, 'G, 'H, 'Output>() =
         {
             Description = spec.Description
             Inputs = spec.Inputs
+            Alias = spec.Alias
             ExtraInputs = spec.ExtraInputs
             Handler = handler
             SubCommands = spec.SubCommands
@@ -120,6 +123,14 @@ type BaseCommandBuilder<'A, 'B, 'C, 'D, 'E, 'F, 'G, 'H, 'Output>() =
     member this.AddCommands (spec: CommandSpec<'Inputs, 'Output>, subCommands: System.CommandLine.Command seq) =
         { spec with SubCommands = spec.SubCommands @ (subCommands |> Seq.toList) }
 
+    [<CustomOperation("addAlias")>]
+    member this.AddCommands (spec: CommandSpec<'Inputs, 'Output>, alias: string seq) =
+        { spec with Alias = spec.Alias @ (alias |> Seq.toList) }
+
+    [<CustomOperation("addAlias")>]
+    member this.AddCommands (spec: CommandSpec<'Inputs, 'Output>, alias: string) =
+        { spec with Alias = alias :: spec.Alias }
+
     /// Registers an additional input that can be manually parsed via the InvocationContext. (Use when more than 8 inputs are required.)
     [<CustomOperation("add")>]
     member this.Add(spec: CommandSpec<'Inputs, 'Output>, extraInput: HandlerInput<'Value>) =
@@ -152,6 +163,7 @@ type BaseCommandBuilder<'A, 'B, 'C, 'D, 'E, 'F, 'G, 'H, 'Output>() =
         )
 
         spec.SubCommands |> List.iter cmd.AddCommand
+        spec.Alias |> List.iter cmd.AddAlias
         cmd
 
     /// Sets a command handler that returns `unit`.

--- a/src/TestConsole/ProgramSubCommand.fs
+++ b/src/TestConsole/ProgramSubCommand.fs
@@ -3,45 +3,48 @@
 open System.IO
 open FSharp.SystemCommandLine
 
-let listCmd = 
-    let handler (dir: DirectoryInfo) = 
-        if dir.Exists 
-        then dir.EnumerateFiles() |> Seq.iter (fun f -> printfn "%s" f.FullName)
-        else printfn $"{dir.FullName} does not exist."
-        
+let listCmd =
+    let handler (dir: DirectoryInfo) =
+        if dir.Exists then
+            dir.EnumerateFiles()
+            |> Seq.iter (fun f -> printfn "%s" f.FullName)
+        else
+            printfn $"{dir.FullName} does not exist."
+
     let dir = Input.Argument("directory", DirectoryInfo(@"c:\default"))
 
     command "list" {
         description "lists contents of a directory"
         inputs dir
         setHandler handler
+        addAlias "ls"
     }
 
-let deleteCmd = 
-    let handler (dir: DirectoryInfo, recursive: bool) = 
-        if dir.Exists then 
-            if recursive
-            then printfn $"Recursively deleting {dir.FullName}"
-            else printfn $"Deleting {dir.FullName}"
-        else 
+let deleteCmd =
+    let handler (dir: DirectoryInfo, recursive: bool) =
+        if dir.Exists then
+            if recursive then
+                printfn $"Recursively deleting {dir.FullName}"
+            else
+                printfn $"Deleting {dir.FullName}"
+        else
             printfn $"{dir.FullName} does not exist."
 
-    let dir = Input.Argument("directory", DirectoryInfo(@"c:\default"))    
+    let dir = Input.Argument("directory", DirectoryInfo(@"c:\default"))
     let recursive = Input.Option("--recursive", false)
 
     command "delete" {
         description "deletes a directory"
         inputs (dir, recursive)
         setHandler handler
+        addAlias [ "d"; "del" ]
     }
-        
 
-//[<EntryPoint>]
-let main argv = 
+
+// [<EntryPoint>]
+let main argv =
     rootCommand argv {
         description "File System Manager"
         setHandler id
         addCommands [ listCmd; deleteCmd ]
     }
-    
-        


### PR DESCRIPTION
This adds support for adding [aliases for commands](https://learn.microsoft.com/en-us/dotnet/standard/commandline/define-commands#define-aliases)

Let me know if anything looks weird!