### PR TITLE
Add a PackageLicenseExpression to the nuget package

### DIFF
--- a/src/FSharp.SystemCommandLine/FSharp.SystemCommandLine.fsproj
+++ b/src/FSharp.SystemCommandLine/FSharp.SystemCommandLine.fsproj
@@ -8,6 +8,7 @@
 	<Authors>Jordan Marr</Authors>
 	<PackageTags>F# fsharp System.CommandLine cli</PackageTags>
 	<PackageProjectUrl>https://github.com/JordanMarr/FSharp.SystemCommandLine</PackageProjectUrl>
+	<PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi,

I've been doing some tests with tools to report on licenses of consume libraries (e.g https://github.com/patriksvensson/covenant) and the report pointed out that the FSharp.SystemCommandLine nuget package didn't specify what license it is, even though there is an MIT license in the source tree.

So - added one in case it's useful to anyone else