### PR TITLE
Added defaultValueMaybe

### DIFF
--- a/src/FSharp.SystemCommandLine/Inputs.fs
+++ b/src/FSharp.SystemCommandLine/Inputs.fs
@@ -94,6 +94,16 @@ module Input =
     /// An alias for `defaultValue` to set the default value of an option or argument.
     let def = defaultValue
 
+    /// Sets the default value of an option or argument.
+    let defaultValueMaybe (defaultValue: 'T option) (input: ActionInput<'T>) =
+        match defaultValue with
+        | Some defaultValue' ->
+            input
+            |> editOption (fun o -> o.DefaultValueFactory <- (fun _ -> defaultValue'))
+            |> editArgument (fun a -> a.DefaultValueFactory <- (fun _ -> defaultValue'))
+        | None ->
+            input
+
     /// Sets the default value factory of an option or argument.
     let defaultValueFactory (defaultValueFactory: Parsing.ArgumentResult -> 'T) (input: ActionInput<'T>) = 
         input


### PR DESCRIPTION
I typically use both `argv` and `appsettings.json` (this provides default values). If the value is not found in `argv` I then look at `appsettings.json` and use the default (if it exists). Based on existing code, I've created `defaultValueMaybe` that will apply a default value if one exists. 

Please note that I've removed additional code that is not relevant.

``` f#
// Proposed new defaultValueMaybe function
module Input =

    /// Sets the default value of an option or argument if it exists.
    let defaultValueMaybe (defaultValue: 'T option) (input: ActionInput<'T>) =
        match defaultValue with
        | Some defaultValue' ->
            input
            |> editOption (fun o -> o.DefaultValueFactory <- (fun _ -> defaultValue'))
            |> editArgument (fun a -> a.DefaultValueFactory <- (fun _ -> defaultValue'))
        | None ->
            input

// Common code
let tryGetDefaultValue (sectionAndName: string) =
    let configNameValue = config[sectionAndName]

    match String.IsNullOrWhiteSpace(configNameValue) with
    | true -> None
    | false -> Some (DirectoryInfo configNameValue)

let description = "Test description"
let aliases = [ "--directory"; "-d" ] 

// Using defaultValueMaybe - I think this is cleaner
option<DirectoryInfo> "directory"
|> Input.description description
|> Input.aliases aliases
|> Input.defaultValueMaybe (tryGetDefaultValue "section1:directory")
|> required
|> validateDirectoryExists

// Using defaultValue
let tempOption =
    option<DirectoryInfo> "directory"
    |> Input.description description
    |> Input.aliases aliases
    |> required
    |> validateDirectoryExists

match tryGetDefaultValue "section1:directory" with
| Some d -> tempOption |> defaultValue d
| None -> tempOption
```