### PR TITLE
Added HelpName and AcceptLegalFilePathsOnly

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The new `Input` module contains functions for the underlying System.CommandLine 
 * `optionMaybe` creates a named `Option<'T option>` that defaults to `None`.
 
 ### Input Properties
+* `acceptLegalFilePathsOnly` sets the option or argument to accept only values representing legal file paths.
 * `alias` adds an `Alias` to an `Option`
 * `aliases` adds one or more aliases to an `Option`
 * `desc` adds a description to an `Option` or `Argument`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The new `Input` module contains functions for the underlying System.CommandLine 
 * `desc` adds a description to an `Option` or `Argument`
 * `defaultValue` or `def` provides a default value to an `Option` or `Argument`
 * `defFactory` assigns a default value factor to an `Option` or `Argument`
+* `helpName` adds the name used in help output to describe the option or argument.
 * `required` marks an `Option` as required
 * `validate` allows you to return a `Result<unit, string>` for the parsed value
 * `validateFileExists` ensures that the `FileInfo` exists

--- a/src/FSharp.SystemCommandLine/Inputs.fs
+++ b/src/FSharp.SystemCommandLine/Inputs.fs
@@ -68,6 +68,12 @@ module Input =
         | _ -> ()
         input
 
+    /// Configures the option or argument to accept only values representing legal file paths.
+    let acceptLegalFilePathsOnly (input: ActionInput<'T>) =
+        input
+        |> editOption (fun o -> o.AcceptLegalFilePathsOnly() |> ignore)
+        |> editArgument (fun a -> a.AcceptLegalFilePathsOnly() |> ignore)
+
     /// Adds one or more aliases to an option.
     let aliases (aliases: string seq) (input: ActionInput<'T>) = 
         input |> editOption (fun o -> aliases |> Seq.iter o.Aliases.Add)

--- a/src/FSharp.SystemCommandLine/Inputs.fs
+++ b/src/FSharp.SystemCommandLine/Inputs.fs
@@ -100,6 +100,12 @@ module Input =
         |> editOption (fun o -> o.DefaultValueFactory <- defaultValueFactory)
         |> editArgument (fun a -> a.DefaultValueFactory <- defaultValueFactory)
 
+    /// The name used in help output to describe the option or argument.
+    let helpName (helpName: string) (input: ActionInput<'T>) =
+        input
+        |> editOption (fun o -> o.HelpName <- helpName)
+        |> editArgument (fun a -> a.HelpName <- helpName)
+
     /// Marks an option as required.
     let required (input: ActionInput<'T>) = 
         input |> editOption (fun o -> o.Required <- true)


### PR DESCRIPTION
Added to `Option`, `Argument` and `README.md`.
Added `AcceptLegalFilePathsOnly` to `Option`, `Argument` and `README.md`.