### PR TITLE
Added missing ZeroOrOne

### DIFF
--- a/src/FSharp.SystemCommandLine/Inputs.fs
+++ b/src/FSharp.SystemCommandLine/Inputs.fs
@@ -71,6 +71,7 @@ type Arity =
     static member inline op_Implicit(argumentArity: ArgumentArity) : Arity = 
         match argumentArity.MinimumNumberOfValues, argumentArity.MaximumNumberOfValues with
         | 0, 0 -> Zero
+        | 0, 1 -> ZeroOrOne
         | 0, max when max = 100_000 -> ZeroOrMore
         | min, max when min = max -> ExactlyOne
         | min, max when min = 1 && max = 100_000 -> OneOrMore


### PR DESCRIPTION
I think you missed this:

``` F#
    /// Implicitly convert an ArgumentArity instance to an Arity DU.
    static member inline op_Implicit(argumentArity: ArgumentArity) : Arity = 
        match argumentArity.MinimumNumberOfValues, argumentArity.MaximumNumberOfValues with
        | 0, 0 -> Zero
        | 0, 1 -> ZeroOrOne               // <<<<<<<<<<<
        | 0, max when max = 100_000 -> ZeroOrMore
        | min, max when min = max -> ExactlyOne
        | min, max when min = 1 && max = 100_000 -> OneOrMore
        | min, max when min > 0 && max = 100_000 -> MinimumNumberOfValues min
        | min, max when min = 0 && max < 100_000 -> MaximumNumberOfValues max
        | _ -> ArgumentArity (argumentArity.MinimumNumberOfValues, argumentArity.MaximumNumberOfValues)
```